### PR TITLE
Add prop to control rendering of book circulation links.

### DIFF
--- a/packages/web-opds-client/CHANGELOG.md
+++ b/packages/web-opds-client/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Changelog
 
+### v1.0.0
+
+- In the Book component, the circulation links (e.g. Borrow, Download) are no longer rendered by default. There is now a showCirculationLinks prop that must be set to true to render the circulation links.
+- The Collection component now has a showCirculationLinks prop that controls the rendering of circulation links on the Books in the Collection.
+
 ### v0.6.4
 
 - Initial Palace release.

--- a/packages/web-opds-client/src/components/Book.tsx
+++ b/packages/web-opds-client/src/components/Book.tsx
@@ -19,6 +19,7 @@ export interface BookProps {
   updateBook: (url: string | undefined) => Promise<BookData>;
   isSignedIn?: boolean;
   epubReaderUrlTemplate?: (epubUrl: string) => string;
+  showCirculationLinks?: boolean;
 }
 
 /** Displays a single book for use in a lane, list, or grid view. */
@@ -89,7 +90,9 @@ export default class Book<P extends BookProps> extends React.Component<P, {}> {
                 </div>
               )}
             </div>
-            <div className="circulation-links">{this.circulationLinks()}</div>
+            {this.props.showCirculationLinks && (
+              <div className="circulation-links">{this.circulationLinks()}</div>
+            )}
           </div>
           <div className="details">
             <div className="fields" lang="en">

--- a/packages/web-opds-client/src/components/Collection.tsx
+++ b/packages/web-opds-client/src/components/Collection.tsx
@@ -12,6 +12,7 @@ export interface CollectionProps extends React.HTMLProps<Collection> {
   isFetchingCollection?: boolean;
   isFetchingBook?: boolean;
   isFetchingPage?: boolean;
+  showCirculationLinks?: boolean;
   error?: FetchErrorData;
   fetchPage?: (url: string) => Promise<any>;
   updateBook: (url: string) => Promise<BookData>;
@@ -111,6 +112,7 @@ export default class Collection extends React.Component<CollectionProps, {}> {
                       updateBook={this.props.updateBook}
                       isSignedIn={this.props.isSignedIn}
                       epubReaderUrlTemplate={this.props.epubReaderUrlTemplate}
+                      showCirculationLinks={this.props.showCirculationLinks}
                     />
                   </li>
                 ))}

--- a/packages/web-opds-client/src/components/__tests__/Collection-test.tsx
+++ b/packages/web-opds-client/src/components/__tests__/Collection-test.tsx
@@ -103,6 +103,7 @@ describe("Collection", () => {
           fulfillBook={fulfillBook}
           indirectFulfillBook={indirectFulfillBook}
           setPreference={setPreference}
+          showCirculationLinks={false}
         />,
         {
           context,
@@ -129,6 +130,14 @@ describe("Collection", () => {
       expect(books.length).to.equal(collectionData.books.length);
       expect(bookDatas).to.deep.equal(collectionData.books);
       expect(uniqueCollectionUrls).to.deep.equal([collectionData.url]);
+    });
+
+    it("passes showCirculationLinks prop to books", () => {
+      const books = wrapper.find(Book);
+
+      books.forEach(book =>
+        expect(book.props().showCirculationLinks).to.equal(false)
+      );
     });
 
     it("shows grid or list view", () => {


### PR DESCRIPTION
## Description

This makes the rendering of book circulation links optional.
- In the `Book` component, the circulation links (e.g. Borrow, Download) are no longer rendered by default. There is now a `showCirculationLinks` prop that must be set to true to render the circulation links.
- The `Collection` component now accepts a `showCirculationLinks` prop that controls the rendering of circulation links on the Books rendered in the `Collection`.

## Motivation and Context

This allows users of web-opds-client to control whether or not circulation links are rendered, and allows us to remove the circulation links from the catalog list view in circulation-admin. Notion: https://www.notion.so/lyrasis/Hide-Borrow-button-when-viewing-titles-in-list-view-after-opening-a-lane-in-the-Collection-Manager-b00a7e7bac244b57a6abf2a737f42510

## How Has This Been Tested?

- Run the app (npm run dev), and enter the URL of a feed, e.g. https://cerberus.tpp-qa.lyrasistechnology.org/cerberus-test-1/feed/1206
- When the feed is rendered, there should be no "Borrow" buttons.

Unit tests are included.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
