### PR TITLE
Add a prop to allow a custom fetcher to be supplied to OPDSCatalog (PP-2398)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ _NOTE_: The web reader has been taken out of the demo server template for now as
   - `history`: an array of link objects (each with `url` and `text` properties) that is appended every time the user navigates to a new collection
 - `epubReaderUrlTemplate(epubUrl: string) => string`: optional function that returns a URL where you can read an EPUB file.
 - `allLanguageSearch`: optional string to specify if searches in the catalog should not use the browser's language header in requests. Default: `false`
+- `fetcher`: optional custom instance of `DataFetcher` to use for network requests. If not provided, a new instance will be created. Default: `undefined`
 
 ## React Component
 
@@ -63,6 +64,7 @@ For an example of the application in use as a React component, see [ThePalacePro
 - `authPlugins`: same as in "Standalone Config Options" above
 - `computeBreadcrumbs`: same as in "Standalone Config Options" above
 - `epubReaderUrlTemplate`: same as in "Standalone Config Options" above
+- `fetcher`: same as in "Standalone Config Options" above
 
 ### React Component Context
 

--- a/packages/web-opds-client/CHANGELOG.md
+++ b/packages/web-opds-client/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### v1.0.2
+
+- Add support for custom DataFetcher instances. The `OPDSCatalog` and `Root` components now accept an optional `fetcher` prop that allows passing in a custom `DataFetcher` instance for network requests.
+
 ### v1.0.1
 
 - Upgrade dependencies to support Node 18.

--- a/packages/web-opds-client/CHANGELOG.md
+++ b/packages/web-opds-client/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Changelog
 
-### v1.0.2
+### v1.1.0
 
 - Add support for custom DataFetcher instances. The `OPDSCatalog` and `Root` components now accept an optional `fetcher` prop that allows passing in a custom `DataFetcher` instance for network requests.
 

--- a/packages/web-opds-client/src/components/OPDSCatalog.tsx
+++ b/packages/web-opds-client/src/components/OPDSCatalog.tsx
@@ -6,6 +6,7 @@ import Root from "./Root";
 import { State } from "../state";
 import AuthPlugin from "../AuthPlugin";
 import OPDSStore from "./context/StoreContext";
+import DataFetcher from "../DataFetcher";
 
 export interface OPDSCatalogProps {
   collectionUrl?: string;
@@ -15,6 +16,7 @@ export interface OPDSCatalogProps {
   proxyUrl?: string;
   initialState?: State;
   epubReaderUrlTemplate?: (epubUrl: string) => string;
+  fetcher?: DataFetcher;
 }
 
 /**

--- a/packages/web-opds-client/src/components/Root.tsx
+++ b/packages/web-opds-client/src/components/Root.tsx
@@ -35,6 +35,7 @@ import {
 } from "../interfaces";
 import AuthPlugin from "../AuthPlugin";
 import { loanedBookData, collectionDataWithLoans } from "../utils";
+import DataFetcher from "../DataFetcher";
 
 export interface HeaderProps extends React.Props<{}> {
   collectionTitle: string | null;
@@ -100,6 +101,7 @@ export interface RootProps extends StateProps {
   closeErrorAndHideAuthForm?: () => void;
   setPreference: (key: string, value: string) => void;
   allLanguageSearch?: boolean;
+  fetcher?: DataFetcher;
 }
 
 export interface RootState {

--- a/packages/web-opds-client/src/components/__tests__/OPDSCatalog-test.tsx
+++ b/packages/web-opds-client/src/components/__tests__/OPDSCatalog-test.tsx
@@ -3,7 +3,7 @@ import { stub } from "sinon";
 
 import * as React from "react";
 import * as PropTypes from "prop-types";
-import { shallow } from "enzyme";
+import { shallow, mount } from "enzyme";
 import { ReactReduxContext } from "react-redux";
 
 import OPDSCatalog from "../OPDSCatalog";

--- a/packages/web-opds-client/src/components/__tests__/OPDSCatalog-test.tsx
+++ b/packages/web-opds-client/src/components/__tests__/OPDSCatalog-test.tsx
@@ -9,6 +9,7 @@ import { ReactReduxContext } from "react-redux";
 import OPDSCatalog from "../OPDSCatalog";
 import Root, { RootProps } from "../Root";
 import { mockRouterContext } from "../../__mocks__/routing";
+import DataFetcher from "../../DataFetcher";
 
 describe("OPDSCatalog", () => {
   let props = {
@@ -47,5 +48,26 @@ describe("OPDSCatalog", () => {
     Object.keys(props).forEach(key => {
       expect(root.props()[key]).to.equal(props[key]);
     });
+  });
+
+  it("passes custom DataFetcher to Root", () => {
+    const customFetcher = new DataFetcher();
+    const propsWithFetcher = {
+      ...props,
+      fetcher: customFetcher
+    };
+
+    let wrapper = shallow(<OPDSCatalog {...propsWithFetcher} />, {
+      context,
+      childContextTypes: {
+        router: PropTypes.object,
+        pathFor: PropTypes.func
+      }
+    });
+
+    const root = wrapper.dive().dive().dive().dive();
+
+    // Verify that the fetcher prop is passed to the Root component
+    expect(root.props().fetcher).to.equal(customFetcher);
   });
 });

--- a/packages/web-opds-client/src/components/__tests__/OPDSCatalog-test.tsx
+++ b/packages/web-opds-client/src/components/__tests__/OPDSCatalog-test.tsx
@@ -57,7 +57,7 @@ describe("OPDSCatalog", () => {
       fetcher: customFetcher
     };
 
-    let wrapper = shallow(<OPDSCatalog {...propsWithFetcher} />, {
+    const wrapper = mount(<OPDSCatalog {...propsWithFetcher} />, {
       context,
       childContextTypes: {
         router: PropTypes.object,
@@ -65,7 +65,10 @@ describe("OPDSCatalog", () => {
       }
     });
 
-    const root = wrapper.dive().dive().dive().dive();
+    const root = wrapper.find(Root);
+
+    // Verify that we found exactly one `Root` component.
+    expect(root).to.have.length(1);
 
     // Verify that the fetcher prop is passed to the Root component
     expect(root.props().fetcher).to.equal(customFetcher);

--- a/packages/web-opds-client/src/components/__tests__/mergeRootProps-test.ts
+++ b/packages/web-opds-client/src/components/__tests__/mergeRootProps-test.ts
@@ -2,6 +2,7 @@ import { expect } from "chai";
 import { stub, spy } from "sinon";
 
 import ActionCreator from "../../actions";
+import DataFetcher from "../../DataFetcher";
 
 // synchronous actions for simple testing
 // of createFetchCollectionAndBook
@@ -113,6 +114,82 @@ describe("mergeRootProps", () => {
     title: "fake book title",
     url: "fake book url"
   };
+
+  it("uses custom DataFetcher if provided in componentProps", () => {
+    const customFetcher = new DataFetcher();
+
+    // We'll use a regular function stub that we can inspect
+    const createDispatchPropsSpy = stub();
+    createDispatchPropsSpy.returns({
+      fetchCollection: stub().returns(Promise.resolve({})),
+      clearCollection: stub(),
+      loadBook: stub(),
+      fetchBook: stub().returns(Promise.resolve({})),
+      clearBook: stub(),
+      updateBook: stub().returns(Promise.resolve({})),
+      fetchLoans: stub().returns(Promise.resolve({}))
+    });
+
+    const dispatchProps = {
+      createDispatchProps: createDispatchPropsSpy
+    };
+
+    const componentProps = {
+      fetcher: customFetcher
+    };
+
+    const stateProps = {
+      loadedCollectionUrl: null,
+      loadedBookUrl: null,
+      collectionUrl: null,
+      bookUrl: null,
+      loansUrl: null,
+      auth: { credentials: null }
+    };
+
+    mergeRootProps(stateProps, dispatchProps, componentProps);
+
+    expect(createDispatchPropsSpy.calledOnce).to.be.true;
+    expect(createDispatchPropsSpy.firstCall.args[0]).to.equal(customFetcher);
+  });
+
+  it("creates new DataFetcher if not provided in componentProps", () => {
+    // We'll use a regular function stub that we can inspect
+    const createDispatchPropsSpy = stub();
+    createDispatchPropsSpy.returns({
+      fetchCollection: stub().returns(Promise.resolve({})),
+      clearCollection: stub(),
+      loadBook: stub(),
+      fetchBook: stub().returns(Promise.resolve({})),
+      clearBook: stub(),
+      updateBook: stub().returns(Promise.resolve({})),
+      fetchLoans: stub().returns(Promise.resolve({}))
+    });
+
+    const dispatchProps = {
+      createDispatchProps: createDispatchPropsSpy
+    };
+
+    const componentProps = {
+      proxyUrl: "test-proxy-url"
+    };
+
+    const stateProps = {
+      loadedCollectionUrl: null,
+      loadedBookUrl: null,
+      collectionUrl: null,
+      bookUrl: null,
+      loansUrl: null,
+      auth: { credentials: null }
+    };
+
+    mergeRootProps(stateProps, dispatchProps, componentProps);
+
+    expect(createDispatchPropsSpy.calledOnce).to.be.true;
+
+    const passedFetcher = createDispatchPropsSpy.firstCall.args[0];
+    expect(passedFetcher).to.be.an.instanceof(DataFetcher);
+  });
 
   beforeEach(() => {
     fetchCollection = spy(url => {

--- a/packages/web-opds-client/src/components/mergeRootProps.ts
+++ b/packages/web-opds-client/src/components/mergeRootProps.ts
@@ -146,10 +146,12 @@ export function mergeRootProps(
   createDispatchProps,
   componentProps
 ) {
-  let fetcher = new DataFetcher({
-    proxyUrl: componentProps.proxyUrl,
-    adapter: adapter
-  });
+  let fetcher =
+    componentProps.fetcher ||
+    new DataFetcher({
+      proxyUrl: componentProps.proxyUrl,
+      adapter: adapter
+    });
   let dispatchProps = createDispatchProps.createDispatchProps(fetcher);
   let authCredentials = fetcher.getAuthCredentials();
 


### PR DESCRIPTION
## Description
  
This PR adds support for custom `DataFetcher` instances in the OPDS client. The changes allow passing a custom `DataFetcher` through the `fetcher` prop to both the `OPDSCatalog` component and the `Root` component.

## Motivation and Context

 Currently, the `OPDSCatalog` component always creates a new `DataFetcher` internally, which limits customization options for network requests. This change allows applications to provide their own `DataFetcher` implementations with custom logic for authorization, request handling, proxying, or other network-related functionality.

See https://github.com/ThePalaceProject/circulation/pull/2417 and PP-2398 for use case.

## How Has This Been Tested?

  The changes have been tested with:
  - Unit tests for the OPDSCatalog component to verify it passes the custom fetcher prop to Root
  - Unit tests for mergeRootProps to verify it uses the provided fetcher or creates a new one if none is provided
  - Manual testing to ensure the fetcher is used correctly throughout the component hierarchy

  The implementation maintains backward compatibility since the fetcher prop is optional, with the default behavior unchanged when no custom fetcher is provided.

## Checklist:

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
