### PR TITLE
Ignore dependabot PRs when publishing documentation

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -11,6 +11,10 @@ jobs:
   gh-pages:
     runs-on: ubuntu-latest
 
+    # Don't publish documentation if the commit was made by dependabot, since
+    # dependabot does not have permissions to push to the gh-pages branch.
+    if: github.actor != 'dependabot[bot]'
+
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v2


### PR DESCRIPTION
## Description

Add a conditional to the gh-pages.yml github action to exclude dependabot.

## Motivation and Context

When merging dependabot PRs to `main` the publish documentation action is failing because dependabot does not have the correct permissions. 

Since dependabot should just be dependency updates, no need to re-publish docs for these PRs anyway. This saves having CI fail every time we merge one a dependabot PR.

## How Has This Been Tested?

- Hard to test outside of CI
- I took the expression used to check for dependabot PRs from here: https://docs.github.com/en/code-security/dependabot/troubleshooting-dependabot/troubleshooting-dependabot-on-github-actions#troubleshooting-failures-when-dependabot-triggers-existing-workflows

## Checklist:

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
