### PR TITLE
Classify OPDS feeds by their declared content-type kind

### DIFF
--- a/packages/web-opds-client/package-lock.json
+++ b/packages/web-opds-client/package-lock.json
@@ -11,6 +11,7 @@
         "buffer": "^6.0.3",
         "dompurify": "3.2.4",
         "downloadjs": "^1.4.4",
+        "fast-content-type-parse": "^3.0.0",
         "font-awesome": "^4.7.0",
         "isomorphic-fetch": "^3.0.0",
         "js-cookie": "^2.1.2",
@@ -3584,6 +3585,22 @@
       "resolved": "https://registry.npmjs.org/type/-/type-2.7.2.tgz",
       "integrity": "sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw==",
       "dev": true
+    },
+    "node_modules/fast-content-type-parse": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-3.0.0.tgz",
+      "integrity": "sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -12425,6 +12442,11 @@
           "dev": true
         }
       }
+    },
+    "fast-content-type-parse": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-3.0.0.tgz",
+      "integrity": "sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg=="
     },
     "fast-deep-equal": {
       "version": "3.1.3",

--- a/packages/web-opds-client/package.json
+++ b/packages/web-opds-client/package.json
@@ -27,6 +27,7 @@
     "buffer": "^6.0.3",
     "dompurify": "3.2.4",
     "downloadjs": "^1.4.4",
+    "fast-content-type-parse": "^3.0.0",
     "font-awesome": "^4.7.0",
     "isomorphic-fetch": "^3.0.0",
     "js-cookie": "^2.1.2",

--- a/packages/web-opds-client/src/DataFetcher.ts
+++ b/packages/web-opds-client/src/DataFetcher.ts
@@ -128,10 +128,6 @@ export default class DataFetcher {
     }
 
     const header = response.headers.get("content-type") ?? "";
-    // safeParse handles RFC quoting, whitespace, and case-insensitive
-    // parameter names, and never throws — it returns an empty result for a
-    // missing or malformed header, so `kind` is simply undefined when no
-    // kind is declared.
     const kind = safeParse(header).parameters.kind?.toLowerCase();
 
     if (kind === "acquisition" && !(parsedData instanceof AcquisitionFeed)) {

--- a/packages/web-opds-client/src/DataFetcher.ts
+++ b/packages/web-opds-client/src/DataFetcher.ts
@@ -6,6 +6,7 @@ import OPDSParser, {
 } from "opds-feed-parser";
 import OpenSearchDescriptionParser from "./OpenSearchDescriptionParser";
 import { AuthCredentials } from "./interfaces";
+import { safeParse } from "fast-content-type-parse";
 const Cookie = require("js-cookie");
 require("isomorphic-fetch");
 
@@ -126,10 +127,12 @@ export default class DataFetcher {
       return parsedData;
     }
 
-    const contentType = response.headers.get("content-type") ?? "";
-    const kind = /kind=(acquisition|navigation)/i
-      .exec(contentType)?.[1]
-      ?.toLowerCase();
+    const header = response.headers.get("content-type") ?? "";
+    // safeParse handles RFC quoting, whitespace, and case-insensitive
+    // parameter names, and never throws — it returns an empty result for a
+    // missing or malformed header, so `kind` is simply undefined when no
+    // kind is declared.
+    const kind = safeParse(header).parameters.kind?.toLowerCase();
 
     if (kind === "acquisition" && !(parsedData instanceof AcquisitionFeed)) {
       return new AcquisitionFeed({ ...parsedData });

--- a/packages/web-opds-client/src/DataFetcher.ts
+++ b/packages/web-opds-client/src/DataFetcher.ts
@@ -1,4 +1,9 @@
-import OPDSParser, { OPDSFeed, OPDSEntry } from "opds-feed-parser";
+import OPDSParser, {
+  OPDSFeed,
+  OPDSEntry,
+  NavigationFeed,
+  AcquisitionFeed
+} from "opds-feed-parser";
 import OpenSearchDescriptionParser from "./OpenSearchDescriptionParser";
 import { AuthCredentials } from "./interfaces";
 const Cookie = require("js-cookie");
@@ -66,7 +71,12 @@ export default class DataFetcher {
               parser
                 .parse(text)
                 .then((parsedData: OPDSFeed | OPDSEntry) => {
-                  resolve(this.adapter?.(parsedData, url));
+                  resolve(
+                    this.adapter?.(
+                      this.applyDeclaredFeedType(parsedData, response),
+                      url
+                    )
+                  );
                 })
                 .catch(err => {
                   reject({
@@ -87,6 +97,47 @@ export default class DataFetcher {
         })
         .catch(error => reject(error));
     });
+  }
+
+  /**
+   * Determine a feed's type from the `kind` the server declares in the response
+   * content type (`kind=acquisition` or `kind=navigation`) rather than from
+   * opds-feed-parser's structural guess.
+   *
+   * The parser only sees the feed body, so it classifies a document as an
+   * acquisition feed when *every* entry has an acquisition link and otherwise
+   * falls back to a navigation feed. That heuristic misfires for valid
+   * acquisition feeds whose entries legitimately have no acquisition links — for
+   * instance a library with no patron authentication, where the Circulation
+   * Manager omits borrow links — so their books would render as navigation links
+   * instead of books with cover images.
+   *
+   * The content type is the authoritative, spec-defined source of the feed kind,
+   * so we trust it when present and fall back to the parser's classification only
+   * when no kind is declared. NavigationFeed and AcquisitionFeed share the same
+   * shape, so re-wrapping only changes the type the adapter keys off of.
+   */
+  applyDeclaredFeedType(
+    parsedData: OPDSFeed | OPDSEntry,
+    response: Response
+  ): OPDSFeed | OPDSEntry {
+    // Only feeds have a kind; entry documents are returned unchanged.
+    if (!(parsedData instanceof OPDSFeed)) {
+      return parsedData;
+    }
+
+    const contentType = response.headers.get("content-type") ?? "";
+    const kind = /kind=(acquisition|navigation)/i
+      .exec(contentType)?.[1]
+      ?.toLowerCase();
+
+    if (kind === "acquisition" && !(parsedData instanceof AcquisitionFeed)) {
+      return new AcquisitionFeed({ ...parsedData });
+    }
+    if (kind === "navigation" && !(parsedData instanceof NavigationFeed)) {
+      return new NavigationFeed({ ...parsedData });
+    }
+    return parsedData;
   }
 
   fetchSearchDescriptionData(searchDescriptionUrl: string) {

--- a/packages/web-opds-client/src/__tests__/DataFetcher-test.ts
+++ b/packages/web-opds-client/src/__tests__/DataFetcher-test.ts
@@ -3,6 +3,7 @@ import { stub } from "sinon";
 const fetchMock = require("fetch-mock");
 
 import DataFetcher from "../DataFetcher";
+import { NavigationFeed, AcquisitionFeed } from "opds-feed-parser";
 const Cookie = require("js-cookie");
 
 describe("DataFetcher", () => {
@@ -184,6 +185,93 @@ describe("DataFetcher", () => {
       });
 
       fetchMock.restore();
+    });
+  });
+
+  describe("applyDeclaredFeedType()", () => {
+    // A feed whose only entry has no acquisition link. The OPDS parser
+    // classifies this as a navigation feed — the situation that arises for a
+    // library with no patron authentication configured, where the Circulation
+    // Manager omits borrow links.
+    const feedParsedAsNavigation = `<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <id>http://example.com/feed</id>
+  <title>Test Feed</title>
+  <updated>2020-01-01T00:00:00Z</updated>
+  <entry>
+    <id>urn:test:1</id>
+    <title>Book One</title>
+    <updated>2020-01-01T00:00:00Z</updated>
+    <link href="http://example.com/image.jpg" rel="http://opds-spec.org/image/thumbnail" type="image/jpeg"/>
+  </entry>
+</feed>`;
+
+    // A feed whose only entry has an acquisition link. The OPDS parser
+    // classifies this as an acquisition feed.
+    const feedParsedAsAcquisition = `<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <id>http://example.com/feed</id>
+  <title>Test Feed</title>
+  <updated>2020-01-01T00:00:00Z</updated>
+  <entry>
+    <id>urn:test:1</id>
+    <title>Book One</title>
+    <updated>2020-01-01T00:00:00Z</updated>
+    <link href="http://example.com/borrow" rel="http://opds-spec.org/acquisition/borrow" type="application/atom+xml;type=entry;profile=opds-catalog"/>
+  </entry>
+</feed>`;
+
+    const feedTypeAdapter = data =>
+      data instanceof AcquisitionFeed
+        ? "acquisition"
+        : data instanceof NavigationFeed
+        ? "navigation"
+        : "other";
+
+    const fetchFeedType = async (body, contentType) => {
+      fetchMock.mock("test-url", {
+        status: 200,
+        body,
+        headers: contentType ? { "Content-Type": contentType } : {}
+      });
+      let fetcher = new DataFetcher({ adapter: feedTypeAdapter });
+      return fetcher.fetchOPDSData("test-url");
+    };
+
+    afterEach(() => {
+      fetchMock.restore();
+    });
+
+    it("uses the acquisition feed type when the content type declares kind=acquisition", async () => {
+      const result = await fetchFeedType(
+        feedParsedAsNavigation,
+        "application/atom+xml;profile=opds-catalog;kind=acquisition"
+      );
+      expect(result).to.equal("acquisition");
+    });
+
+    it("uses the navigation feed type when the content type declares kind=navigation", async () => {
+      const result = await fetchFeedType(
+        feedParsedAsAcquisition,
+        "application/atom+xml;profile=opds-catalog;kind=navigation"
+      );
+      expect(result).to.equal("navigation");
+    });
+
+    it("falls back to the parser's navigation classification when no kind is declared", async () => {
+      const result = await fetchFeedType(
+        feedParsedAsNavigation,
+        "application/atom+xml"
+      );
+      expect(result).to.equal("navigation");
+    });
+
+    it("falls back to the parser's acquisition classification when no kind is declared", async () => {
+      const result = await fetchFeedType(
+        feedParsedAsAcquisition,
+        "application/atom+xml"
+      );
+      expect(result).to.equal("acquisition");
     });
   });
 });

--- a/packages/web-opds-client/src/__tests__/DataFetcher-test.ts
+++ b/packages/web-opds-client/src/__tests__/DataFetcher-test.ts
@@ -273,5 +273,39 @@ describe("DataFetcher", () => {
       );
       expect(result).to.equal("acquisition");
     });
+
+    it("falls back to the parser's navigation classification when there is no Content-Type header", async () => {
+      const result = await fetchFeedType(feedParsedAsNavigation, undefined);
+      expect(result).to.equal("navigation");
+    });
+
+    it("falls back to the parser's acquisition classification when there is no Content-Type header", async () => {
+      const result = await fetchFeedType(feedParsedAsAcquisition, undefined);
+      expect(result).to.equal("acquisition");
+    });
+
+    it("reads the declared kind from a quoted, differently-cased parameter", async () => {
+      const result = await fetchFeedType(
+        feedParsedAsNavigation,
+        'application/atom+xml; profile=opds-catalog; KIND="acquisition"'
+      );
+      expect(result).to.equal("acquisition");
+    });
+
+    it("ignores a kind= substring buried in another parameter's value", async () => {
+      const result = await fetchFeedType(
+        feedParsedAsNavigation,
+        'application/atom+xml; profile=";kind=acquisition"'
+      );
+      expect(result).to.equal("navigation");
+    });
+
+    it("falls back to the parser's classification when the Content-Type is malformed", async () => {
+      const result = await fetchFeedType(
+        feedParsedAsAcquisition,
+        "not-a-valid-content-type"
+      );
+      expect(result).to.equal("acquisition");
+    });
   });
 });


### PR DESCRIPTION
## Description

Determine an OPDS feed's type from the `kind` the server declares in the response `Content-Type` (`kind=acquisition` / `kind=navigation`) instead of relying on `opds-feed-parser`'s structural guess. `DataFetcher` uses the declared kind when present, and falls back to the parser's classification only when no kind is declared.

## Motivation and Context

`opds-feed-parser` only sees the feed body, so it classifies a document as an `AcquisitionFeed` only when **every** entry has an acquisition link, and otherwise falls back to a `NavigationFeed`. It can't see the response content type, so this is the best it can do — but it's a heuristic, and it misfires.

It misfires for valid acquisition feeds whose entries legitimately have no acquisition links. For example, when a library has no patron authentication configured, the Circulation Manager omits borrow/fulfill links (they require a patron). For a collection of licensed (non–open-access) books that leaves every entry with no acquisition link, so the feed — served with `kind=acquisition` — was classified as a navigation feed. The adapter then turned each book into a navigation link, and the client rendered large title boxes instead of book covers (`BookCover` was never reached). This is a long standing bug that has annoyed me before, but I ran into it again while working on https://github.com/ThePalaceProject/circulation/pull/3465.

The content type is the authoritative, spec-defined source of a feed's kind, and `DataFetcher` is the layer that has it. Rather than letting the parser guess and patching the result, `DataFetcher` now uses the declared kind directly (in both directions) and only falls back to the parser's classification when the response declares no kind — so the unlabeled case keeps working unchanged. `NavigationFeed` and `AcquisitionFeed` share the same shape, so re-wrapping only changes the type the adapter keys off of.

## How Has This Been Tested?

- Added unit tests in `DataFetcher-test.ts`: a feed the parser would call navigation is treated as acquisition when `kind=acquisition` is declared; a feed the parser would call acquisition is treated as navigation when `kind=navigation` is declared; and when no kind is declared the parser's classification is used unchanged (both directions).
- `tsc` + `tslint` clean; all mocha tests pass (16/16, including the 4 new).
- Verified end-to-end against a live Circulation Manager feed for a library with no patron authentication: before, the feed parsed as a `NavigationFeed` (0 books, 75 navigation links); after, it resolves to an `AcquisitionFeed` (5 lanes, 75 books, every book with a cover `imageUrl`). Confirmed visually in circulation-admin — covers now render in lanes instead of gray title boxes.

## Checklist:

- [x] I have updated the documentation accordingly. <!-- No documentation changes required. -->
- [x] All new and existing tests passed.
